### PR TITLE
Add pagedown preview and options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'coffee-rails', '~> 4.0.0'
 gem 'bootstrap-sass'
 
 gem 'better_errors'
+gem 'quiet_assets'
 
 gem 'rspec-rails', group: [ :test, :development ]
 gem 'pry-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -29,4 +29,5 @@ gem 'pry-rails'
 
 group :test do
   gem 'simplecov', require: false
+  gem 'generator_spec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,9 @@ GEM
     diff-lcs (1.2.4)
     erubis (2.7.0)
     execjs (2.0.1)
+    generator_spec (0.9.0)
+      activerecord (>= 3.0, <= 4.0)
+      railties (>= 3.0, <= 4.0)
     hike (1.2.3)
     i18n (0.6.5)
     jquery-rails (3.0.1)
@@ -144,6 +147,7 @@ DEPENDENCIES
   bootstrap-sass
   bootstrap_pagedown!
   coffee-rails (~> 4.0.0)
+  generator_spec
   jquery-rails
   pry-rails
   quiet_assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bootstrap_pagedown (1.0.1)
+    bootstrap_pagedown (1.0.2)
       rails (>= 3.2)
 
 GEM
@@ -70,6 +70,8 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.2)
       pry (>= 0.9.10)
+    quiet_assets (1.0.2)
+      railties (>= 3.1, < 5.0)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -144,6 +146,7 @@ DEPENDENCIES
   coffee-rails (~> 4.0.0)
   jquery-rails
   pry-rails
+  quiet_assets
   rspec-rails
   sass-rails (~> 4.0.0)
   simplecov

--- a/README.md
+++ b/README.md
@@ -49,9 +49,40 @@ You may also add attributes to the generated text area as needed by simply addin
 
 The previous example would add `data-name="editor"` to the editor textarea element.
 
-### Note
+### Custom options supported:
 
-You should only use one editor per page since `Pagedown`'s Javascript relies on the HTML id attribute for most of it's behavior.
+By default bootstrap_pagedown will create the needed HTML elements to render a functional editor with a button bar and a preview div.
+However you can change the different element classes, ids and even skip the preview div by passing different options to the `pagedown_editor`
+method, here's the hash with different options and it's default values:
+
+```ruby
+{
+  skip_preview:     false,             # Whether or not we should skip the preview div, skipping this will render an editor without HTML preview
+  panel_id:         '',                # HTML id of the editor panel div
+  panel_class:      'wmd-panel',       # HTML class of the editor panel div
+  button_bar_id:    'wmd-button-bar',  # HTML id of the editor's button bar div
+  button_bar_class: '',                # HTML class of the editor's button bar div
+  editor_id:        'wmd-input',       # HTML if of the editor textarea
+  editor_class:     'wmd-input',       # HTML class of the editor textarea
+  preview_id:       'wmd-preview',     # HTML id of the preview div
+  preview_class:    '',                # HTML class of the preview div
+}
+```
+
+This is a the default generated HTML, note that name will change depending on your form builder and method name.
+
+```html
+<div class="wmd-panel">
+  <div id="wmd-button-bar"></div>
+  <textarea class="wmd-input" id="wmd-input" name="test[test]"></textarea>
+  <div id="wmd-preview"></div>
+</div>
+```
+
+If you change the any of the default ids or classes on the HTML elements the `pagedown_editor` will render the correct HTML, but the editor won't render
+that is because by default Pagedown looks for those element attribute values, however you can still get the editor to render and behave correctly through the
+[Pagedown API](https://code.google.com/p/pagedown/wiki/PageDown). I other words in order to have more than one editor in the same page you'll obviously have to
+change the element attributes and the use the Pagedown API to create every aditional editor.
 
 ## Running the test suite
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ that is because by default Pagedown looks for those element attribute values, ho
 [Pagedown API](https://code.google.com/p/pagedown/wiki/PageDown). I other words in order to have more than one editor in the same page you'll obviously have to
 change the element attributes and the use the Pagedown API to create every aditional editor.
 
+## Stylesheets
+
+If you need to change something on the stylesheets you don't need to start from scratch, you can simply generate the sass file with the sass generator as follows:
+
+`rails g bootstrap_pagedown:sass`
+
+This will generate a copy of bootstrap_pagedown styles into `app/assets/stylesheets`.
+
 ## Running the test suite
 
 Simply clone this project (or pull) and then run `rake`

--- a/lib/bootstrap_pagedown/form_builder.rb
+++ b/lib/bootstrap_pagedown/form_builder.rb
@@ -1,10 +1,32 @@
 module BootstrapPagedown
   module FormBuilder
-    def pagedown_editor( method, options={})
-      @template.content_tag( :div, class: 'wmd-panel' ) do
-        @template.content_tag( :div, nil, id: 'wmd-button-bar' ) +
-        @template.text_area( @object_name, method, objectify_options( options ).merge( id: 'wmd-input', class: 'wmd-input' ) )
+    def pagedown_editor(method, options={})
+      options         = pagedown_default_values options
+      custom_options  = pagedown_custom_attributes options
+
+      @template.content_tag( :div, id: options[:panel_id], class: options[:panel_class] ) do
+        @template.content_tag( :div, nil, id: options[:button_bar_id], class: options[:button_bar_class] ) +
+        @template.text_area( @object_name, method, objectify_options( custom_options ).merge( id: options[:editor_id], class: options[:editor_class] ) ) +
+
+        unless options[:skip_preview]
+          @template.content_tag :div, nil, id: options[:preview_id], class: options[:preview_class]
+        end
       end
+    end
+
+    def pagedown_default_values( options )
+      options[:skip_preview]  ||= false
+      options[:panel_class]   ||= 'wmd-panel'
+      options[:button_bar_id] ||= 'wmd-button-bar'
+      options[:editor_id]     ||= 'wmd-input'
+      options[:editor_class]  ||= 'wmd-input'
+      options[:preview_id]    ||= 'wmd-preview'
+
+      options
+    end
+
+    def pagedown_custom_attributes( options )
+      options.except :skip_preview, :panel_class, :panel_id, :button_bar_id, :button_bar_class, :editor_id, :editor_class, :preview_id, :preview_class
     end
   end
 end

--- a/lib/bootstrap_pagedown/version.rb
+++ b/lib/bootstrap_pagedown/version.rb
@@ -1,3 +1,3 @@
 module BootstrapPagedown
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/lib/generators/bootstrap_pagedown/sass_generator.rb
+++ b/lib/generators/bootstrap_pagedown/sass_generator.rb
@@ -1,14 +1,14 @@
 module BootstrapPagedown
   module Generators
     class SassGenerator < ::Rails::Generators::Base
-      VENDOR_PATH = '../../../../vendor/assets/stylesheets/'
+      VENDOR_PATH = File.expand_path( '../../../../vendor/assets/stylesheets/', __FILE__ )
 
-      source_root File.expand_path( VENDOR_PATH, __FILE__ )
+      source_root VENDOR_PATH
 
       desc "Generates the editor stylesheet"
 
       def copy_sass
-        directory File.expand_path( VENDOR_PATH, __FILE__ ), 'app/assets/stylesheets'
+        directory VENDOR_PATH, 'app/assets/stylesheets'
       end
     end
   end

--- a/lib/generators/bootstrap_pagedown/sass_generator.rb
+++ b/lib/generators/bootstrap_pagedown/sass_generator.rb
@@ -1,0 +1,15 @@
+module BootstrapPagedown
+  module Generators
+    class SassGenerator < ::Rails::Generators::Base
+      VENDOR_PATH = '../../../../vendor/assets/stylesheets/'
+
+      source_root File.expand_path( VENDOR_PATH, __FILE__ )
+
+      desc "Generates the editor stylesheet"
+
+      def copy_sass
+        directory File.expand_path( File.join( VENDOR_PATH ), __FILE__ ), 'app/assets/stylesheets'
+      end
+    end
+  end
+end

--- a/lib/generators/bootstrap_pagedown/sass_generator.rb
+++ b/lib/generators/bootstrap_pagedown/sass_generator.rb
@@ -8,7 +8,7 @@ module BootstrapPagedown
       desc "Generates the editor stylesheet"
 
       def copy_sass
-        directory File.expand_path( File.join( VENDOR_PATH ), __FILE__ ), 'app/assets/stylesheets'
+        directory File.expand_path( VENDOR_PATH, __FILE__ ), 'app/assets/stylesheets'
       end
     end
   end

--- a/spec/bootstrap_pagedown/form_builder_spec.rb
+++ b/spec/bootstrap_pagedown/form_builder_spec.rb
@@ -5,6 +5,14 @@ module BootstrapPagedown
   WITH_OPTIONS    = '<textarea class="wmd-input" data-editor="true" id="wmd-input" name="page[body]">'
   TOOLBAR         = '<div id="wmd-button-bar">'
   WRAPPER         = '<div class="wmd-panel">'
+  PAGEDOWN_DEFAULTS = {
+    skip_preview:   false,
+    panel_class:    'wmd-panel',
+    button_bar_id:  'wmd-button-bar',
+    editor_id:      'wmd-input',
+    editor_class:   'wmd-input',
+    preview_id:     'wmd-preview',
+  }
 
   describe FormBuilder do
     let( :builder ) { ActionView::Helpers::FormBuilder }
@@ -41,6 +49,30 @@ module BootstrapPagedown
       it 'should render the wrapper div' do
         editor = subject.pagedown_editor :body
         editor.should include( WRAPPER )
+      end
+    end
+
+    describe :pagedown_default_values do
+      it 'sets a list of default values if these have not been set' do
+        options = subject.pagedown_default_values( {} )
+        options.should eql( PAGEDOWN_DEFAULTS )
+      end
+
+      it 'will keep any value previously set' do
+        options = subject.pagedown_default_values skip_preview: true
+        options[:skip_preview].should be_true
+      end
+
+      it 'will keep any value even if it is not part of the defaults' do
+        options = subject.pagedown_default_values foo: :bar
+        options[:foo].should eql( :bar )
+      end
+    end
+
+    describe :pagedown_custom_attributes do
+      it 'will sanitize default options' do
+        custom_options = subject.pagedown_custom_attributes PAGEDOWN_DEFAULTS.merge( foo: :bar )
+        custom_options.should eql( foo: :bar )
       end
     end
   end

--- a/spec/generator/sass_generator_spec.rb
+++ b/spec/generator/sass_generator_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'generator_spec/test_case'
+require 'rails/generators'
+require File.expand_path( '../../lib/generators/bootstrap_pagedown/sass_generator.rb', File.dirname( __FILE__ ) )
+
+
+module BootstrapPagedown
+  module Generators
+    describe SassGenerator do
+      include GeneratorSpec::TestCase
+      destination File.expand_path( '../../tmp', __FILE__ )
+
+      before do
+        prepare_destination
+        run_generator
+      end
+
+      it 'should generate bootstrap_pagedown sass' do
+        assert_file( 'app/assets/stylesheets/bootstrap_pagedown.css.scss' )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR aims to add a review div to Pagedown in order to render the markdown converted to HTML and give the user the option to remove the preview and change the HTML attributes of his generated editor.
